### PR TITLE
Change dangling comma rule to allow when it's multiline

### DIFF
--- a/common.js
+++ b/common.js
@@ -176,8 +176,8 @@ module.exports = {
     ],
     // "capitalized-comments": "warn",
     "comma-dangle": [
-      "error",
-      "never"
+      "warn",
+      "always-multiline"
     ],
     "comma-spacing": [
       "error",


### PR DESCRIPTION
### Request for discussion

- Can we change this rule to enforce dangling commas when it's multiline?
- This change would reduce diff line number, and remove unnecessary green or red highlighted lines at pr review when it is only a comma added or removed at the end of line.