### PR TITLE
Update rules according to `hipo-frontend-project-starter`

### DIFF
--- a/common.js
+++ b/common.js
@@ -154,7 +154,7 @@ module.exports = {
         args: "none"
       }
     ],
-    "no-use-before-define": "error",
+    "no-use-before-define": ["error", { "functions": false, "classes": true }],
     // stylistic
     "array-bracket-spacing": [
       "error",

--- a/common.js
+++ b/common.js
@@ -38,7 +38,7 @@ module.exports = {
     "complexity": [
       "error",
       {
-        max: 10
+        max: 20
       }
     ],
     "consistent-return": "error",

--- a/common.js
+++ b/common.js
@@ -168,12 +168,7 @@ module.exports = {
       "error",
       "1tbs"
     ],
-    "camelcase": [
-      "error",
-      {
-        properties: "never"
-      }
-    ],
+    "camelcase": "off",
     // "capitalized-comments": "warn",
     "comma-dangle": [
       "error",

--- a/es2015.js
+++ b/es2015.js
@@ -73,8 +73,14 @@ module.exports = {
     "prefer-destructuring": [
       "error",
       {
-        array: false,
-        object: true
+        "VariableDeclarator": {
+          "array": false,
+          "object": true
+        },
+        "AssignmentExpression": {
+          "array": false,
+          "object": false
+        }
       },
       {
         enforceForRenamedProperties: false


### PR DESCRIPTION
* Update `prefer-destructuring` rule
* Update `complexity` max limit to `20`
* Update `no-use-before-define` rule
* Turn off `camelcase` rule completely
* `class-methods-use-this`, `func-names` and `id-length` rules are not included to this PR since their default behavior is already `0`

[hipo-frontend-project-starter eslint rules](https://github.com/Hipo/hipo-frontend-project-starter/blob/71d95a95e61cc8932c84d555e38024956f030e52/.eslintrc.js)
Related issue: #11