### PR TITLE
Use `eslint-plugin-import` to order imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Set your eslint config to:
 
 ## TypeScript
 
-* Disable `no-undef` in your eslint config as TSC already catches related errors. Enabled `no-undef` rule causes problems if you try to use TS only features like `enums`.
+* Disable `no-undef` in your eslint config as TSC already catches related errors. Enabled `no-undef` rule causes problems if you try to use TS only features like `enum`.
   ```
   {
     rules:{

--- a/README.md
+++ b/README.md
@@ -20,21 +20,30 @@ Set your eslint config to:
 
 ## TypeScript
 
-If you are using TypeScript, to avoid false `import/no-unresolved` errors, you should add `plugin:import/typescript` to your eslint config **(RECOMMENDED)**:
-
-```
-{
-  "extends": ["@hipo/eslint-config-base", "plugin:import/typescript"]
-}
-```
-
-or you can turn off `"import/no-unresolved"` rule in your eslint config:
-
-```
-{
-  rules:{
-    ...
-    "import/no-unresolved": "off"
+* Disable `no-undef` in your eslint config as TSC already catches related errors. `no-undef` rule causes problems if you try to use TS only features like `enums`.
+  ```
+  {
+    rules:{
+      ...
+      "no-undef": "off"
+    }
   }
-}
-```
+  ```
+* To avoid false `import/no-unresolved` errors, you should add `plugin:import/typescript` to your eslint config **(RECOMMENDED)**:
+
+  ```
+  {
+    "extends": ["@hipo/eslint-config-base", "plugin:import/typescript"]
+  }
+  ```
+
+  or you can turn off `"import/no-unresolved"` rule in your eslint config:
+
+  ```
+  {
+    rules:{
+      ...
+      "import/no-unresolved": "off"
+    }
+  }
+  ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Set your eslint config to:
 
 ## TypeScript
 
-* Disable `no-undef` in your eslint config as TSC already catches related errors. `no-undef` rule causes problems if you try to use TS only features like `enums`.
+* Disable `no-undef` in your eslint config as TSC already catches related errors. Enabled `no-undef` rule causes problems if you try to use TS only features like `enums`.
   ```
   {
     rules:{

--- a/README.md
+++ b/README.md
@@ -17,3 +17,24 @@ Set your eslint config to:
   "extends": ["@hipo/eslint-config-base"]
 }
 ```
+
+## TypeScript
+
+If you are using TypeScript, to avoid false `import/no-unresolved` errors, you should add `plugin:import/typescript` to your eslint config **(RECOMMENDED)**:
+
+```
+{
+  "extends": ["@hipo/eslint-config-base", "plugin:import/typescript"]
+}
+```
+
+or you can turn off `"import/no-unresolved"` rule in your eslint config:
+
+```
+{
+  rules:{
+    ...
+    "import/no-unresolved": "off"
+  }
+}
+```

--- a/es2015.js
+++ b/es2015.js
@@ -1,6 +1,6 @@
 module.exports = {
   // `eslint-plugin-import` related plugin
-  plugins: ['import'],
+  plugins: ["import"],
   rules: {
     // es6
     "arrow-body-style": [

--- a/es2015.js
+++ b/es2015.js
@@ -1,4 +1,6 @@
 module.exports = {
+  // `eslint-plugin-import` related plugin
+  plugins: ['import'],
   rules: {
     // es6
     "arrow-body-style": [
@@ -46,7 +48,6 @@ module.exports = {
       }
     ],
     "no-new-symbol": "error",
-    // "no-restricted-imports": ["warn", {"paths": [], "patterns": []}],
     "no-this-before-super": "error",
     "no-useless-computed-key": "error",
     "no-useless-constructor": "error",
@@ -86,7 +87,6 @@ module.exports = {
         enforceForRenamedProperties: false
       }
     ],
-    // prefer-numeric-literals: ["warn"],
     "prefer-rest-params": "error",
     "prefer-spread": "error",
     "prefer-template": "error",
@@ -95,7 +95,6 @@ module.exports = {
       "error",
       "never"
     ],
-    // "sort-imports": ["warn"]
     "symbol-description": [
       "error"
     ],
@@ -106,6 +105,31 @@ module.exports = {
     "yield-star-spacing": [
       "error",
       "after"
-    ]
+    ],
+    // `eslint-plugin-import` related rules
+    "import/order": [
+      "error",
+      {
+        "newlines-between": "always",
+        groups: [
+          ["builtin", "external"],
+          ["sibling", "parent", "internal", "index"]
+        ],
+        pathGroups: [
+          {
+            pattern: "*.+(svg|pdf|csv|png)",
+            patternOptions: {
+              dot: true,
+              nocomment: true,
+              matchBase: true
+            },
+            group: "builtin",
+            position: "before"
+          }
+        ]
+      }
+    ],
+    "import/no-duplicates": "error",
+    "import/no-unresolved": "error"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hipo/eslint-config-base",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Shareable ESLint configuations for ECMAScript 5 and beyond",
   "main": "index.js",
   "scripts": {
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/Hipo/eslint-config-hipo-base#readme",
   "peerDependencies": {
-    "eslint": "^7.7.0"
+    "eslint": "^7.7.0",
+    "eslint-plugin-import": "^2.22.1"
   }
 }


### PR DESCRIPTION
* Add three new rules
    * `import/order`: To order imports in a stated order as following: svg|pdf|csv|png - 3rd party - internal
    * `import/no-duplicates`: To prevent to import from the same file from different paths, somehow this cannot be detected by eslint
    * `import/no-unresolved`: To prevent invalid paths for especially `.png`, `.svg`, `.csv` files, this is missed by eslint
* Add new `plugins` field so it will not be necessary to add `import` to projects' `.eslintrc` files
* Bump up major version

[eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import)

Closes #16 