### PR TITLE
fix(common): Remove deprecated `valid-jsdoc` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @hipo/eslint-config-base
 
-Hipo's shareable ESLint configuations for ECMAScript 2015 and beyond.
+Hipo's shareable ESLint configurations for ECMAScript 2015 and beyond.
 
 ## Installation
 

--- a/common.js
+++ b/common.js
@@ -29,7 +29,6 @@ module.exports = {
     "no-unsafe-finally": "error",
     "no-unsafe-negation": "error",
     "use-isnan": "error",
-    "valid-jsdoc": "error",
     "valid-typeof": "error",
     // best practices
     "accessor-pairs": "error",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hipo/eslint-config-base",
-  "version": "4.1.0",
-  "description": "Shareable ESLint configuations for ECMAScript 5 and beyond",
+  "version": "4.1.1",
+  "description": "Shareable ESLint configurations for ECMAScript 5 and beyond",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
### Related Issue
- https://github.com/Hipo/eslint-config-hipo-base/issues/20