### PR TITLE
docs: Remove redundant TS part from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,33 +17,3 @@ Set your eslint config to:
   "extends": ["@hipo/eslint-config-base"]
 }
 ```
-
-## TypeScript
-
-* Disable `no-undef` in your eslint config as TSC already catches related errors. Enabled `no-undef` rule causes problems if you try to use TS only features like `enum`.
-  ```
-  {
-    rules:{
-      ...
-      "no-undef": "off"
-    }
-  }
-  ```
-* To avoid false `import/no-unresolved` errors, you should add `plugin:import/typescript` to your eslint config **(RECOMMENDED)**:
-
-  ```
-  {
-    "extends": ["@hipo/eslint-config-base", "plugin:import/typescript"]
-  }
-  ```
-
-  or you can turn off `"import/no-unresolved"` rule in your eslint config:
-
-  ```
-  {
-    rules:{
-      ...
-      "import/no-unresolved": "off"
-    }
-  }
-  ```


### PR DESCRIPTION
Related issue: https://github.com/Hipo/eslint-config-hipo-base/issues/23